### PR TITLE
Fix top's home dir and specify python2

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -60,7 +60,7 @@ IconAddress={home}/.config/Mutate/scripts/chromebookmarks/star-1.png
 HotKey=
 Argument=need
 [top]
-ScriptAddress=/home/mat/.config/Mutate/scripts/topprocess/top.py
-IconAddress=/home/mat/.config/Mutate/scripts/topprocess/monitor.png
+ScriptAddress={home}/.config/Mutate/scripts/topprocess/top.py
+IconAddress={home}/.config/Mutate/scripts/topprocess/monitor.png
 HotKey=
 Argument=need

--- a/config/scripts/topprocess/top.py
+++ b/config/scripts/topprocess/top.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #!encoding = utf-8
 
 import json


### PR DESCRIPTION
* The top script doesn't work on systems who use python3 as the default Python, so I changed the script to call python2 specifically which will work for systems no matter if they default to python2 or python3.
* mat's home directory got left in the default config. I changed this to match all of the other scripts
