### PR TITLE
Add support for tab/backtab navigation.

### DIFF
--- a/src/plaintext.cpp
+++ b/src/plaintext.cpp
@@ -103,12 +103,12 @@ void PlainText::keyPressEvent(QKeyEvent* event)
     }
     if (listWidget->count() > 0)
     {
-        if (key == Qt::Key_Up)
+        if (key == Qt::Key_Up || key == Qt::Key_Backtab)
         {
             listWidget->setCurrentRow((listWidget->currentRow() + listWidget->count() - 1) % listWidget->count());
             return;
         }
-        if (key == Qt::Key_Down)
+        if (key == Qt::Key_Down || key == Qt::Key_Tab)
         {
             listWidget->setCurrentRow((listWidget->currentRow() + 1) % listWidget->count());
             return;


### PR DESCRIPTION
I made a small change to allow to navigate through the results using tab/back tab.
I do not think tab should be useful for anything else in the input context anyway, so
this should not interfere with current functionalities.