### PR TITLE
Fix Bug for Jumping to Calculator Mode Prematurely

### DIFF
--- a/src/defaulsearch.cpp
+++ b/src/defaulsearch.cpp
@@ -39,7 +39,7 @@ std::vector<returnByScript> defaulSearch::getReturnVec(const pair& map)
     bool searchApp = true;
     bool addCalc = false;
     if (searchApp) netSearch(searchApp);
-    if (searchApp) calcSearch(addCalc);
+    if (searchApp && noScriptMatches()) calcSearch(addCalc);
     searchScripts();
     if (searchApp) searchApps(map, addCalc);
     if (vals.empty() && !keyword.empty())
@@ -51,6 +51,26 @@ std::vector<returnByScript> defaulSearch::getReturnVec(const pair& map)
                            ));
     }
     return vals;
+}
+
+bool defaulSearch::noScriptMatches()
+{
+    try {
+        ConfigParse cp(CONFPATH.c_str());
+        auto sects = cp.getSections();
+        for (auto beg = sects.begin(); beg != sects.end(); beg++)
+        {
+            if (*beg == "default") continue;
+            std::string begtmp = *beg;
+            if (keyword.substr(0, begtmp.size()) == begtmp && keyword[begtmp.size()] == ' ')
+            {
+                return false;
+            }
+        }
+    }
+    catch (...)
+    {}
+    return true;
 }
 
 void defaulSearch::netSearch(bool& searchApp)

--- a/src/defaulsearch.h
+++ b/src/defaulsearch.h
@@ -21,6 +21,7 @@ public:
     void searchScripts();
     void netSearch(bool& searchApp);
     void calcSearch(bool& changeCalc);
+    bool noScriptMatches();
 };
 
 #endif // DEFAULSEARCH_H


### PR DESCRIPTION
This addresses the following issue: https://github.com/qdore/Mutate/issues/60

Before this fix, if you have a parameter for a script that has both
a math symbol and number in it Mutate would jump to calculator mode
and no longer stick with the script it was previously matching. This
was because the calculator check happens before script searches, and
once the script check happened the keyword would be altered.

This prevents calculator checks from happening if the the buffer
matches a script.  This was compiled and tested on Ubuntu 15.04.

Before the applied fix :point_down:  (note I have calc "..." removed in my config so it defaults to search)
![before-the-fix](https://cloud.githubusercontent.com/assets/2657901/10682721/f392a8d6-78fe-11e5-888c-654ae0138306.png)

After the applied fix :point_down: 
![with-the-fix](https://cloud.githubusercontent.com/assets/2657901/10682723/fcd47e2e-78fe-11e5-86f9-c33d61fc787e.png)

